### PR TITLE
ArgumentNullTest.snippet to verify the argument that caused the exception

### DIFF
--- a/ArgumentNullTest.snippet
+++ b/ArgumentNullTest.snippet
@@ -25,14 +25,14 @@
       </Declarations>
       <Code Language="CSharp">
         <![CDATA[class when_I_call_$Method$_with_no_$Argument$ : Context
-	{
+    {
         It throws_an_ArgumentNullException = () =>
         {
             var exception = Catch.Exception(() => $end$);
             exception.ShouldBeOfType<ArgumentNullException>();
-			exception.ShouldContainErrorMessage("$Argument$");
+            exception.ShouldContainErrorMessage("$Argument$");
         };
-	}]]>
+    }]]>
       </Code>
     </Snippet>
   </CodeSnippet>

--- a/ArgumentNullTest.snippet
+++ b/ArgumentNullTest.snippet
@@ -30,6 +30,7 @@
         {
             var exception = Catch.Exception(() => $end$);
             exception.ShouldBeOfType<ArgumentNullException>();
+			exception.ShouldContainErrorMessage("$Argument$");
         };
 	  }]]>
       </Code>

--- a/ArgumentNullTest.snippet
+++ b/ArgumentNullTest.snippet
@@ -25,14 +25,14 @@
       </Declarations>
       <Code Language="CSharp">
         <![CDATA[class when_I_call_$Method$_with_no_$Argument$ : Context
-	  {
+	{
         It throws_an_ArgumentNullException = () =>
         {
             var exception = Catch.Exception(() => $end$);
             exception.ShouldBeOfType<ArgumentNullException>();
 			exception.ShouldContainErrorMessage("$Argument$");
         };
-	  }]]>
+	}]]>
       </Code>
     </Snippet>
   </CodeSnippet>


### PR DESCRIPTION
The ArgumentNullTest snippet could potentially show the argument that is causing the exception. 

```
exception.ShouldContainErrorMessage("$Argument$");
```
